### PR TITLE
fix for #6143 - moment.max doesn't check the first argument to be val…

### DIFF
--- a/src/lib/moment/min-max.js
+++ b/src/lib/moment/min-max.js
@@ -4,16 +4,16 @@ import { createLocal } from '../create/local';
 import { createInvalid } from '../create/valid';
 
 export var prototypeMin = deprecate(
-        'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',
-        function () {
-            var other = createLocal.apply(null, arguments);
-            if (this.isValid() && other.isValid()) {
-                return other < this ? this : other;
-            } else {
-                return createInvalid();
-            }
+    'moment().min is deprecated, use moment.max instead. http://momentjs.com/guides/#/warnings/min-max/',
+    function () {
+        var other = createLocal.apply(null, arguments);
+        if (this.isValid() && other.isValid()) {
+            return other < this ? this : other;
+        } else {
+            return createInvalid();
         }
-    ),
+    }
+),
     prototypeMax = deprecate(
         'moment().max is deprecated, use moment.min instead. http://momentjs.com/guides/#/warnings/min-max/',
         function () {
@@ -39,10 +39,13 @@ function pickBy(fn, moments) {
     if (!moments.length) {
         return createLocal();
     }
-    res = moments[0];
-    for (i = 1; i < moments.length; ++i) {
-        if (!moments[i].isValid() || moments[i][fn](res)) {
-            res = moments[i];
+    res = NaN;
+    if (moments[0].isValid()) {
+        res = moments[0];
+        for (i = 1; i < moments.length; ++i) {
+            if (!moments[i].isValid() || moments[i][fn](res)) {
+                res = moments[i];
+            }
         }
     }
     return res;


### PR DESCRIPTION
Issue #6143: In response to this issue, I've implemented a fix to ensure that moment.max validates the first argument as well as subsequent arguments before performing any comparisons. This ensures consistency and prevents potential errors when utilizing this function. The fix has been implemented and tested, and the changes are ready for review and merging.